### PR TITLE
Require core.norg.dirman

### DIFF
--- a/lua/neorg/modules/core/integrations/telescope/module.lua
+++ b/lua/neorg/modules/core/integrations/telescope/module.lua
@@ -7,7 +7,7 @@ require('neorg.modules.base')
 local module = neorg.modules.create("core.integrations.telescope")
 
 module.setup = function()
-	return { success = true, requires = { "core.keybinds" } }
+	return { success = true, requires = { "core.keybinds", "core.norg.dirman" } }
 end
 
 module.load = function()


### PR DESCRIPTION
I ran into the following error because I did not enable dirman:
```
[neorg] [WARN  23:21:53] ...onfig/nvim/pack/minpac/start/neorg/lua/neorg/modules.lua:215: Attempt to get module with name core.norg.dirman failed - module is not loaded.
```

This PR prevents that issue.